### PR TITLE
Add DocKit — open-source DynamoDB GUI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Rick's talks:
 
 ## Tools
 
+- [DocKit](https://www.geekfun.club/products/dockit/) - Open-source cross-platform GUI client for DynamoDB. Features PartiQL editor, visual query builder, inline data editing, table management with metrics, import/export, DynamoDB Local support, and AI-assisted query generation.
 - [Dynoport](https://www.npmjs.com/package/dynoport) - A CLI tool that allows you to easily import and export data from a specified DynamoDB table. 
 - [Dynobase](https://dynobase.dev/) - Handy tool that makes it easy to view and manipulate your tables, generate application code, and more.
 - [NoSQL Workbench For Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.html) - A tool similar MySQL workbench that lets you model data and interact with your tables without going to the AWS console.


### PR DESCRIPTION
## Summary

Add [DocKit](https://www.geekfun.club/products/dockit/) to the Tools section — an open-source, cross-platform desktop GUI client for DynamoDB.

DocKit is already listed alongside Dynomate and Dynobase in similar awesome lists and provides a free, open-source alternative for DynamoDB GUI management.

**Key features:**
- PartiQL editor with intelligent autocomplete
- Visual Query Builder for interactive data access
- Inline data editing and JSON viewer
- Table management panel with metrics monitoring
- Import/Export data (JSON/CSV)
- DynamoDB Local, LocalStack, and Testcontainers support
- AI-assisted query generation
- Cross-platform (macOS, Windows, Linux)
- Open source (Apache 2.0)

## Placement

Alphabetical order in the Tools section — before Dynoport.