### PR TITLE
Add Tablyne to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Rick's talks:
 - [Dynamo-ts](https://github.com/hexlabsio/dynamo-ts) - DynamoDB + TypeScript made simple - An easier way to interact with DynamoDB using TypeScript.
 - [Dynomate](https://dynomate.io) - Cross-platform DynamoDB GUI client for desktop built with Rust and Tauri. Provides a fast multi-tab UI for browsing tables, running queries, managing items, authenticating with AWS profiles (including SSO & MFA) and more.
 - [dynq](https://github.com/benward2301/dynq) - An analytic query and data processing CLI tool for DynamoDB that uses jq filters to target, transform, and aggregate items, with automatic pagination, table segmentation, and index expansion.
+- [Tablyne](https://tablyne.com) - Native desktop DynamoDB GUI/IDE (Rust + Tauri) for Mac, Windows and Linux. Spreadsheet-style item editing, visual & PartiQL query, a single-table design studio, and bulk operations with a dry-run. Free tier works against DynamoDB Local & LocalStack.
 
 ## Uses
 


### PR DESCRIPTION
Adds [Tablyne](https://tablyne.com) to the Tools section — a native desktop DynamoDB GUI/IDE built in Rust + Tauri (not Electron), available for Mac, Windows and Linux.

It offers spreadsheet-style item editing, visual + PartiQL query, a single-table design studio, and bulk operations with a dry-run. There's a free tier that works fully against DynamoDB Local & LocalStack. Placed it in the Tools section alongside the other GUI clients (Dynobase, Dynomate, NoSQL Workbench). Thanks for maintaining this list!