### PR TITLE
Add Mongrel

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Rick's talks:
 - [Dynamo-ts](https://github.com/hexlabsio/dynamo-ts) - DynamoDB + TypeScript made simple - An easier way to interact with DynamoDB using TypeScript.
 - [Dynomate](https://dynomate.io) - Cross-platform DynamoDB GUI client for desktop built with Rust and Tauri. Provides a fast multi-tab UI for browsing tables, running queries, managing items, authenticating with AWS profiles (including SSO & MFA) and more.
 - [dynq](https://github.com/benward2301/dynq) - An analytic query and data processing CLI tool for DynamoDB that uses jq filters to target, transform, and aggregate items, with automatic pagination, table segmentation, and index expansion.
+- [Mongrel](https://www.visorcraft.com/dynamodb) - Desktop GUI for DynamoDB with table and index browsing, PartiQL queries with capacity insight, native item editing, and backups.
 
 ## Uses
 


### PR DESCRIPTION
Adds [Mongrel](https://www.visorcraft.com/dynamodb) to the Tools section.

Mongrel is a desktop database workbench (Windows, macOS, Linux) with first-class DynamoDB support: table and index browsing, PartiQL queries with capacity insight, native item editing, and backups.

Why include it: it follows the precedent of other commercial DynamoDB GUIs already in this section (e.g. Dynobase, Dynomate) and is a useful, actively maintained tool for DynamoDB users.

Disclosure: this submission is made by the vendor (VisorCraft). Mongrel is proprietary/paid (annual license) with a 7-day free trial.